### PR TITLE
Updates for the latest skia library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,6 @@ extra_compile_args = {
 
 shared_macros = [
     ("SK_SUPPORT_GPU", "0"),
-    ("SK_SUPPORT_LEGACY_PATH_FILLTYPE_ENUM", "1"),
 ]
 define_macros = {
     "": shared_macros,

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,9 @@ skia_src = [
     os.path.join(skia_dir, "src", "core", "SkBuffer.cpp"),
     os.path.join(skia_dir, "src", "core", "SkCubicClipper.cpp"),
     os.path.join(skia_dir, "src", "core", "SkData.cpp"),
+    os.path.join(skia_dir, "src", "core", "SkEdgeClipper.cpp"),
     os.path.join(skia_dir, "src", "core", "SkGeometry.cpp"),
+    os.path.join(skia_dir, "src", "core", "SkLineClipper.cpp"),
     os.path.join(skia_dir, "src", "core", "SkMath.cpp"),
     os.path.join(skia_dir, "src", "core", "SkMatrix.cpp"),
     os.path.join(skia_dir, "src", "core", "SkPath.cpp"),
@@ -342,17 +344,7 @@ elif os.name == "posix":
 else:
     raise RuntimeError("unsupported OS: %r" % os.name)
 
-include_dirs = [
-    os.path.join(skia_dir, 'include', 'config'),
-    os.path.join(skia_dir, 'include', 'core'),
-    os.path.join(skia_dir, 'include', 'pathops'),
-    os.path.join(skia_dir, 'include', 'private'),
-    os.path.join(skia_dir, 'include', 'gpu'),
-    os.path.join(skia_dir, 'src', 'core'),
-    os.path.join(skia_dir, 'src', 'opts'),
-    os.path.join(skia_dir, 'src', 'shaders'),
-    os.path.join(skia_dir),
-]
+include_dirs = [os.path.join(skia_dir)]
 
 extra_compile_args = {
     '': [
@@ -370,6 +362,7 @@ extra_compile_args = {
 
 shared_macros = [
     ("SK_SUPPORT_GPU", "0"),
+    ("SK_SUPPORT_LEGACY_PATH_FILLTYPE_ENUM", "1"),
 ]
 define_macros = {
     "": shared_macros,

--- a/src/cpp/SkMallocThrow.cpp
+++ b/src/cpp/SkMallocThrow.cpp
@@ -2,8 +2,8 @@
 // among other things the `sk_malloc_throw` function below), as the latter
 // has a long list of dependencies which we don't need for skia-pathops.
 // The function is used by SkTArray.h, included by pathops/SkPathWriter.h.
-#include <SkMalloc.h>
-#include <SkSafeMath.h>
+#include "include/private/SkMalloc.h"
+#include "src/core/SkSafeMath.h"
 
 void* sk_malloc_throw(size_t count, size_t elemSize) {
     return sk_malloc_throw(SkSafeMath::Mul(count, elemSize));

--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -1,5 +1,6 @@
 from ._skia.core cimport (
     SkPath,
+    SkPathFillType,
     SkPoint,
     SkScalar,
     kMove_Verb,
@@ -9,10 +10,6 @@ from ._skia.core cimport (
     kCubic_Verb,
     kClose_Verb,
     kDone_Verb,
-    kWinding_FillType,
-    kEvenOdd_FillType,
-    kInverseWinding_FillType,
-    kInverseEvenOdd_FillType,
 )
 from ._skia.pathops cimport (
     SkOpBuilder,
@@ -23,7 +20,7 @@ from ._skia.pathops cimport (
     kXOR_SkPathOp,
     kReverseDifference_SkPathOp,
 )
-from libc.stdint cimport uint8_t, int32_t
+from libc.stdint cimport uint8_t, int32_t, uint32_t
 
 
 cpdef enum PathOp:
@@ -35,10 +32,10 @@ cpdef enum PathOp:
 
 
 cpdef enum FillType:
-    WINDING = kWinding_FillType
-    EVEN_ODD = kEvenOdd_FillType
-    INVERSE_WINDING = kInverseWinding_FillType
-    INVERSE_EVEN_ODD = kInverseEvenOdd_FillType
+    WINDING = <uint32_t>SkPathFillType.kWinding
+    EVEN_ODD = <uint32_t>SkPathFillType.kEvenOdd
+    INVERSE_WINDING = <uint32_t>SkPathFillType.kInverseWinding
+    INVERSE_EVEN_ODD = <uint32_t>SkPathFillType.kInverseEvenOdd
 
 
 cdef union FloatIntUnion:

--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -727,7 +727,7 @@ cdef double get_path_area(const SkPath& path) except? -1234567:
 
     p0 = start_point = SkPoint.Make(.0, .0)
     while True:
-        verb = iterator.next(p, False)
+        verb = iterator.next(p)
         if verb == kMove_Verb:
             p0 = start_point = p[0]
         elif verb == kLine_Verb:

--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -1,5 +1,6 @@
 from ._skia.core cimport (
     SkPath,
+    SkPathFillType,
     SkPoint,
     SkScalar,
     SkRect,
@@ -10,10 +11,6 @@ from ._skia.core cimport (
     kCubic_Verb,
     kClose_Verb,
     kDone_Verb,
-    kWinding_FillType,
-    kEvenOdd_FillType,
-    kInverseWinding_FillType,
-    kInverseEvenOdd_FillType,
     SK_ScalarNearlyZero,
 )
 from ._skia.pathops cimport (
@@ -278,11 +275,12 @@ cdef class Path:
 
     @property
     def fillType(self):
-        return FillType(self.path.getFillType())
+        return FillType(<uint32_t>self.path.getFillType())
 
     @fillType.setter
     def fillType(self, value):
-        self.path.setFillType(FillType(value))
+        cdef uint32_t fill = int(FillType(value))
+        self.path.setFillType(<SkPathFillType>fill)
 
     @property
     def isConvex(self):
@@ -430,7 +428,7 @@ cdef class Path:
     @property
     def contours(self):
         cdef SkPath temp
-        cdef SkPath.FillType fillType = self.path.getFillType()
+        cdef SkPathFillType fillType = self.path.getFillType()
 
         temp.setFillType(fillType)
 
@@ -1019,7 +1017,7 @@ cpdef bint winding_from_even_odd(Path path, bint truetype=False) except False:
         contour = contours[i]
         path.path.addPath(contour.path)
 
-    path.path.setFillType(kWinding_FillType)
+    path.path.setFillType(SkPathFillType.kWinding)
     return True
 
 
@@ -1116,7 +1114,7 @@ cdef int set_contour_start_point(SkPath& path, SkScalar x, SkScalar y) except -1
         reverse_contour(path)
         return 1
 
-    cdef SkPath.FillType fill = path.getFillType()
+    cdef SkPathFillType fill = path.getFillType()
     path.rewind()
     path.setFillType(fill)
 

--- a/src/python/pathops/_skia/core.pxd
+++ b/src/python/pathops/_skia/core.pxd
@@ -4,6 +4,15 @@ from libc.stdint cimport uint8_t
 ctypedef float SkScalar
 
 
+cdef extern from "include/core/SkPathTypes.h":
+
+    enum SkPathFillType:
+        kWinding "SkPathFillType::kWinding",
+        kEvenOdd "SkPathFillType::kEvenOdd",
+        kInverseWinding "SkPathFillType::kInverseWinding",
+        kInverseEvenOdd "SkPathFillType::kInverseEvenOdd"
+
+
 cdef extern from "include/core/SkPath.h":
 
     cdef cppclass SkPoint:
@@ -58,8 +67,8 @@ cdef extern from "include/core/SkPath.h":
 
         void rewind()
 
-        void setFillType(FillType ft)
-        FillType getFillType()
+        void setFillType(SkPathFillType ft)
+        SkPathFillType getFillType()
 
         # TODO also expose optional AddPathMode enum
         void addPath(const SkPath& src) except +
@@ -121,12 +130,6 @@ cdef extern from * namespace "SkPath":
         kCubic_Verb,
         kClose_Verb,
         kDone_Verb
-
-    enum FillType:
-        kWinding_FillType,
-        kEvenOdd_FillType,
-        kInverseWinding_FillType,
-        kInverseEvenOdd_FillType
 
 
 cdef extern from "include/core/SkRect.h":

--- a/src/python/pathops/_skia/core.pxd
+++ b/src/python/pathops/_skia/core.pxd
@@ -4,7 +4,7 @@ from libc.stdint cimport uint8_t
 ctypedef float SkScalar
 
 
-cdef extern from "SkPath.h":
+cdef extern from "include/core/SkPath.h":
 
     cdef cppclass SkPoint:
 
@@ -91,11 +91,6 @@ cdef extern from "SkPath.h":
             Iter() except +
             Iter(const SkPath& path, bint forceClose) except +
 
-            Verb next(SkPoint pts[4],
-                      bint doConsumeDegenerates,
-                      bint exact)
-            Verb next(SkPoint pts[4],
-                      bint doConsumeDegenerates)
             Verb next(SkPoint pts[4])
 
             SkScalar conicWeight()
@@ -134,7 +129,7 @@ cdef extern from * namespace "SkPath":
         kInverseEvenOdd_FillType
 
 
-cdef extern from "SkRect.h":
+cdef extern from "include/core/SkRect.h":
 
     cdef cppclass SkRect:
 
@@ -147,7 +142,7 @@ cdef extern from "SkRect.h":
         bint Intersects(const SkRect& a, const SkRect& b)
 
 
-cdef extern from "SkScalar.h":
+cdef extern from "include/core/SkScalar.h":
 
     cdef enum:
         SK_ScalarNearlyZero

--- a/src/python/pathops/_skia/pathops.pxd
+++ b/src/python/pathops/_skia/pathops.pxd
@@ -1,7 +1,7 @@
 from .core cimport SkPath
 
 
-cdef extern from "SkPathOps.h":
+cdef extern from "include/pathops/SkPathOps.h":
 
     enum SkPathOp:
         kDifference_SkPathOp,            # subtract the op path from the first path


### PR DESCRIPTION
These changes are needed to be able to use the latest skia library.
However, nothing changes as regards pathops proper.