### PR TITLE
Add Path.transform method to apply 3x3 matrix

### DIFF
--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -15,6 +15,7 @@ from ._skia.core cimport (
     kSmall_ArcSize,
     kLarge_ArcSize,
     SkPathDirection,
+    SkMatrix,
 )
 from ._skia.pathops cimport (
     SkOpBuilder,
@@ -170,6 +171,19 @@ cdef class Path:
     cdef int countContours(self) except -1
 
     cdef int getFirstPoints(self, SkPoint **pp, int *count) except -1
+
+    cpdef Path transform(
+        self,
+        SkScalar scaleX=*,
+        SkScalar skewY=*,
+        SkScalar skewX=*,
+        SkScalar scaleY=*,
+        SkScalar translateX=*,
+        SkScalar translateY=*,
+        SkScalar perspectiveX=*,
+        SkScalar perspectiveY=*,
+        SkScalar perspectiveBias=*,
+    )
 
 
 cpdef enum PathVerb:

--- a/src/python/pathops/_skia/core.pxd
+++ b/src/python/pathops/_skia/core.pxd
@@ -22,6 +22,24 @@ cdef extern from "include/core/SkPathTypes.h":
         kCCW "SkPathDirection::kCCW"
 
 
+cdef extern from "include/core/SkMatrix.h":
+    cdef cppclass SkMatrix:
+        SkMatrix() except +
+
+        @staticmethod
+        SkMatrix MakeAll(
+            SkScalar scaleX,
+            SkScalar skewX,
+            SkScalar transX,
+            SkScalar skewY,
+            SkScalar scaleY,
+            SkScalar transY,
+            SkScalar pers0,
+            SkScalar pers1,
+            SkScalar pers2,
+        )
+
+
 cdef extern from "include/core/SkPath.h":
 
     cdef cppclass SkPoint:
@@ -132,6 +150,8 @@ cdef extern from "include/core/SkPath.h":
             Verb peek()
 
             SkScalar conicWeight()
+
+        void transform(const SkMatrix& matrix, SkPath* dst) const
 
 
 cdef extern from * namespace "SkPath":

--- a/tests/pathops_test.py
+++ b/tests/pathops_test.py
@@ -118,6 +118,44 @@ class PathTest(object):
             # ('lineTo', ((100.0, 100.0),)),
             ('closePath', ())]
 
+    def test_transform(self):
+        path = Path()
+        path.moveTo(125, 376)
+        path.cubicTo(181, 376, 218, 339, 218, 290)
+        path.cubicTo(218, 225, 179, 206, 125, 206)
+        path.close()
+
+        # t = Transform().rotate(radians(-45)).translate(-100, 0)
+        matrix = (0.707107, -0.707107, 0.707107, 0.707107, -70.7107, 70.7107)
+
+        result = path.transform(*matrix)
+
+        expected = Path()
+        expected.moveTo(
+            bits2float(0x438dc663),  # 283.55
+            bits2float(0x437831ce),  # 248.195
+        )
+        expected.cubicTo(
+            bits2float(0x43a192ee),  # 323.148
+            bits2float(0x435098b8),  # 208.597
+            bits2float(0x43a192ee),  # 323.148
+            bits2float(0x431c454a),  # 156.271
+            bits2float(0x43903ff5),  # 288.5
+            bits2float(0x42f33ead),  # 121.622
+        )
+        expected.cubicTo(
+            bits2float(0x437289a8),  # 242.538
+            bits2float(0x42975227),  # 75.6605
+            bits2float(0x43498688),  # 201.526
+            bits2float(0x42b39aee),  # 89.8026
+            bits2float(0x4323577c),  # 163.342
+            bits2float(0x42fff906),  # 127.986
+        )
+        expected.close()
+
+        result.dump(as_hex=True)
+        assert result == expected
+
 
 class OpBuilderTest(object):
 


### PR DESCRIPTION
The order of the parameters follows SVG transform affine matrix `[a b c d e f]`, to allow unpacking a 6-tuple as positional args:

```python
path = Path()
...
matrix = (1.5, 0, 0, 1.5, 0, 0)
result = path.transform(*matrix)
```

