### PR TITLE
Path.stroke should not call convertConicsToQuads itself

### DIFF
--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -453,10 +453,6 @@ cdef class Path:
         finally:
             del stroke_rec
 
-        # Nuke any conics that snuck in
-        self.convertConicsToQuads()
-
-
     cdef list getVerbs(self):
         cdef int i, count
         cdef uint8_t *verbs


### PR DESCRIPTION
clients can call that directly (passing the desired tolerance) if they wish to get rid of conics.