### PR TITLE
decompose components in PathPen; raise error when no glyphSet provided

### DIFF
--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -102,7 +102,7 @@ cdef class Path:
     @staticmethod
     cdef Path create(const SkPath& path)
 
-    cpdef PathPen getPen(self, bint allow_open_paths=*)
+    cpdef PathPen getPen(self, object glyphSet=*, bint allow_open_paths=*)
 
     cpdef void moveTo(self, SkScalar x, SkScalar y)
 
@@ -232,6 +232,7 @@ cdef class SegmentPenIterator:
 cdef class PathPen:
 
     cdef Path path
+    cdef object glyphSet
     cdef bint allow_open_paths
 
     cpdef moveTo(self, pt)

--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -895,7 +895,7 @@ cdef class PathPen:
 
     cpdef addComponent(self, glyphName, transformation):
         if self.glyphSet is None:
-            raise ValueError("Missing required glyphSet; can't decompose components")
+            raise TypeError("Missing required glyphSet; can't decompose components")
 
         base_glyph = self.glyphSet[glyphName]
         cdef Path base_path = Path()

--- a/tests/pathops_test.py
+++ b/tests/pathops_test.py
@@ -160,7 +160,7 @@ class PathTest(object):
     def test_pen_addComponent_missing_required_glyphSet(self):
         path = Path()
         pen = path.getPen()
-        with pytest.raises(ValueError, match="Missing required glyphSet"):
+        with pytest.raises(TypeError, match="Missing required glyphSet"):
             pen.addComponent("a", (1, 0, 0, 1, 0, 0))
 
     def test_pen_addComponent_decomposed_from_glyphSet(self):

--- a/tests/pathops_test.py
+++ b/tests/pathops_test.py
@@ -157,6 +157,53 @@ class PathTest(object):
         result.dump(as_hex=True)
         assert result == expected
 
+    def test_pen_addComponent_missing_required_glyphSet(self):
+        path = Path()
+        pen = path.getPen()
+        with pytest.raises(ValueError, match="Missing required glyphSet"):
+            pen.addComponent("a", (1, 0, 0, 1, 0, 0))
+
+    def test_pen_addComponent_decomposed_from_glyphSet(self):
+        a = Path()
+        a.moveTo(0, 0)
+        a.lineTo(1, 0)
+        a.lineTo(1, 1)
+        a.lineTo(0, 1)
+        a.close()
+        glyphSet = {"a": a}
+
+        b = Path()
+        pen = b.getPen(glyphSet=glyphSet)
+        pen.addComponent("a", (2, 0, 0, 2, 10, 10))
+        glyphSet["b"] = b
+
+        assert list(b) == [
+            (PathVerb.MOVE, ((10, 10),)),
+            (PathVerb.LINE, ((12, 10),)),
+            (PathVerb.LINE, ((12, 12),)),
+            (PathVerb.LINE, ((10, 12),)),
+            (PathVerb.CLOSE, ()),
+        ]
+
+        c = Path()
+        pen = c.getPen(glyphSet=glyphSet)
+        pen.addComponent("a", (1, 0, 0, 1, 2, 2))
+        pen.addComponent("b", (1, 0, 0, 1, -10, -10))
+        glyphSet["c"] = c
+
+        assert list(c) == [
+            (PathVerb.MOVE, ((2, 2),)),
+            (PathVerb.LINE, ((3, 2),)),
+            (PathVerb.LINE, ((3, 3),)),
+            (PathVerb.LINE, ((2, 3),)),
+            (PathVerb.CLOSE, ()),
+            (PathVerb.MOVE, ((0, 0),)),
+            (PathVerb.LINE, ((2, 0),)),
+            (PathVerb.LINE, ((2, 2),)),
+            (PathVerb.LINE, ((0, 2),)),
+            (PathVerb.CLOSE, ()),
+        ]
+
 
 class OpBuilderTest(object):
 


### PR DESCRIPTION
Fixes #29

Adds a new `glyphSet=None` parameter to the `Path.getPen` method (and to the `PathPen` constructor), which will be used to decompose components when the pen.addComponent() method is called. 
If no glyphSet is provided (default), then calling the pen.addComponent will raise `TypeError`.
We will no longer silently ignore/drop components. We may add an option to do that if/when need arise.