### PR TITLE
WIP Keep track of on-curve points in the original path

### DIFF
--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -99,6 +99,8 @@ cdef class Path:
 
     cdef SkPath path
 
+    cdef set originalOnCurvePoints
+
     @staticmethod
     cdef Path create(const SkPath& path)
 
@@ -224,6 +226,7 @@ cdef class RawPathIterator:
 
 cdef class SegmentPenIterator:
 
+    cdef set originalOnCurvePoints
     cdef _SkPointArray pa
     cdef SkPoint *pts
     cdef _VerbArray va

--- a/tests/pathops_test.py
+++ b/tests/pathops_test.py
@@ -106,6 +106,30 @@ class PathTest(object):
             ('qCurveTo', ((1.0, 1.0), (2.0, 2.0), (3.0, 3.0))),
             ('closePath', ())]
 
+    def test_decompose_join_quadratic_segments_preserve_original_oncurves(self):
+        path = Path()
+        pen = path.getPen()
+        pen.moveTo((0, 0))
+        pen.qCurveTo((1, 1), (1.5, 1.5)) # This time the on-curve is explicit
+        pen.qCurveTo((2, 2), (3, 3))
+        pen.closePath()
+
+        items = list(path)
+        assert len(items) == 4
+        # the TrueType quadratic spline with N off-curves is stored internally
+        # as N atomic quadratic Bezier segments
+        assert items[1][0] == PathVerb.QUAD
+        assert items[1][1] == ((1.0, 1.0), (1.5, 1.5))
+        assert items[2][0] == PathVerb.QUAD
+        assert items[2][1] == ((2.0, 2.0), (3.0, 3.0))
+
+        # when drawn back onto a SegmentPen, the implicit on-curves are omitted
+        assert list(path.segments) == [
+            ('moveTo', ((0.0, 0.0),)),
+            ('qCurveTo', ((1.0, 1.0), (1.5, 1.5))),
+            ('qCurveTo', ((2.0, 2.0), (3.0, 3.0))),
+            ('closePath', ())]
+
     def test_last_implicit_lineTo(self):
         # https://github.com/fonttools/skia-pathops/issues/6
         path = Path()


### PR DESCRIPTION
Hello @anthrotype ! This is both an issue and a pull request that starts to fix the issue. Here is the problem: a designer drew a "registered" sign that is so symmetrical that the code in skia-pathops to reconstruct long quadratic curves with implicit points from the small quadratic curves that come out of Skia thought that the top extrema of the curve, which was a real on-curve point initially, was actually an implicit point and made it disappear. That then caused confusion when the designer was trying to hint the glyph in VTT. See screenshots: on the left, the glyph as it comes out of current skia-pathops, on the right as it comes out with this patch.

![image](https://user-images.githubusercontent.com/3616772/120688075-96445380-c49a-11eb-8547-7a3e5b708184.png)   ![image](https://user-images.githubusercontent.com/3616772/120688116-a2c8ac00-c49a-11eb-8383-25f6e9066a41.png)

I added a test and I'm proposing a way to fix this by remembering the coordinates of the intended on-curve points in the Path object, and then making sure that they're still on-curve after reconstructing the long qCurveTo commands.

However I didn't finish implementing this properly because I'm not sure how thorough I should be with this, e.g. right now it only works if you draw on the Path with its pen, but doesn't if you add path bits via the Path methods...

Also I haven't figured out how to use the Skia matrix transformation to transform single points (needed to keep track of "original on-curves" while decomposing components with transformations).

And also it's the first time I touch Cython code and I don't know whether I'm trashing performance with my changes.
