### PR TITLE
make PathPen curveTo/qCurveTo accept variable number of points

### DIFF
--- a/src/python/pathops/__init__.py
+++ b/src/python/pathops/__init__.py
@@ -14,6 +14,7 @@ from ._pathops import (
     PathOpsError,
     UnsupportedVerbError,
     OpenPathError,
+    NumberOfPointsError,
     bits2float,
     float2bits,
     decompose_quadratic_segment,

--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -247,7 +247,7 @@ cdef class PathPen:
 
     cpdef lineTo(self, pt)
 
-    cpdef curveTo(self, pt1, pt2, pt3)
+    # def curveTo(self, *points)
 
     # def qCurveTo(self, *points)
 


### PR DESCRIPTION
When constructing a `pathops.Path` using the `PathPen`, we should handle variable number of point arguments to `curveTo` and `qCurveTo` methods, following fontTools' BasePen which is the blueprint of all segment-based pens.

https://github.com/fonttools/fonttools/blob/35856412485bce4a1e6c08cceb52c7a87c75c4ee/Lib/fontTools/pens/basePen.py#L274-L329

as well as the UFO GLIF spec: https://github.com/unified-font-object/ufo-spec/issues/211

Should fix => https://github.com/googlefonts/ufo2ft/issues/468#issuecomment-1311574944