### PR TITLE
Update uses of Skia's old unspanned APIs

### DIFF
--- a/src/python/pathops/_pathops.pxd
+++ b/src/python/pathops/_pathops.pxd
@@ -266,6 +266,8 @@ cdef class _SkScalarArray:
     @staticmethod
     cdef _SkScalarArray create(object values)
 
+    cdef SkSpan[SkScalar] as_span(self)
+
 
 cdef int pts_in_verb(SkPathVerb v) except -1
 

--- a/src/python/pathops/_pathops.pyx
+++ b/src/python/pathops/_pathops.pyx
@@ -526,7 +526,7 @@ cdef class Path:
             if intervals.count % 2 != 0:
                 raise ValueError("Expected an even number of dash_array entries")
             paint.setPathEffect(
-                SkDashPathEffect.Make(intervals.data, intervals.count, dash_offset)
+                SkDashPathEffect.Make(<SkSpan[const SkScalar]>intervals.as_span(), dash_offset)
             )
 
         FillPathWithPaint(self.path.detach(), paint, &self.path)
@@ -1103,6 +1103,9 @@ cdef class _SkScalarArray:
 
     def __dealloc__(self):
         PyMem_Free(self.data)  # no-op if data is NULL
+
+    cdef SkSpan[SkScalar] as_span(self):
+        return SkSpan[SkScalar](self.data, self.count)
 
 
 cdef inline int pts_in_verb(SkPathVerb v) except -1:

--- a/src/python/pathops/_skia/core.pxd
+++ b/src/python/pathops/_skia/core.pxd
@@ -6,6 +6,8 @@ ctypedef float SkScalar
 
 cdef extern from "include/core/SkSpan.h":
     cdef cppclass SkSpan[T]:
+        SkSpan()
+        SkSpan(T* data, size_t size)
         SkSpan[T] subspan(size_t offset) const
         T& operator[](size_t) const
         bint empty() const
@@ -240,7 +242,7 @@ cdef extern from "include/core/SkPathEffect.h":
 cdef extern from "include/effects/SkDashPathEffect.h":
     cdef cppclass SkDashPathEffect:
         @staticmethod
-        sk_sp[SkPathEffect] Make(const SkScalar intervals[], int count, SkScalar phase)
+        sk_sp[SkPathEffect] Make(SkSpan[const SkScalar] intervals, SkScalar phase)
 
 
 cdef extern from "include/core/SkPaint.h":


### PR DESCRIPTION
These changes uses of deprecated and soon-to-be-removed APIs that were bare pointers and counts of things to be the more ergonomic SkSpan.
It should be a pure refactor with no functional change.