### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "setuptools_scm",
+    "packaging",
     "cython >= 3.2.0",
 ]
 


### PR DESCRIPTION
pkg_resources is no longer available in Setuptools 82.0.0. Replace with importlib.metadata and packaging.version for Cython version checking.

Fixes #84